### PR TITLE
Integration with OpenCPN timeline widget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ set(VERSION_DATE  "20/01/2023")#DD/MM/YYYY format
 set(OCPN_MIN_VERSION "ov58")
 
 set(OCPN_API_VERSION_MAJOR "1")
-set(OCPN_API_VERSION_MINOR "18")
+set(OCPN_API_VERSION_MINOR "21")
 set(TP_COMMENT "  * Release using CI")
 
 set(PARENT "opencpn")
@@ -218,7 +218,7 @@ if (NOT OCPN_FLATPAK_CONFIG)
     target_link_libraries(${PACKAGE_NAME} windows::headers)
   endif (WIN32)
 
-    add_subdirectory(opencpn-libs/api-18)
+    add_subdirectory(opencpn-libs/api-21)
     target_link_libraries(${PACKAGE_NAME} ocpn::api)
 
     add_subdirectory(opencpn-libs/tinyxml)

--- a/include/ClimatologyDialog.h
+++ b/include/ClimatologyDialog.h
@@ -65,6 +65,7 @@ public:
     void PopulateTrackingControls();
     void RefreshRedraw();
     void SetCursorLatLon(double lat, double lon);
+    void UpdateFromTimeline(const wxDateTime &selectedTime);
     bool SettingEnabled(int setting);
     void DisableSetting(int setting);
 
@@ -82,14 +83,7 @@ private:
 
     wxString GetValue(int index, Coord coord=MAG);
 
-    void DayMonthUpdate();
-    void OnMonth( wxCommandEvent& event ) { DayMonthUpdate(); }
-    void OnDay( wxSpinEvent& event ) { DayMonthUpdate(); }
-    void OnTimeline( wxScrollEvent& event );
-    void OnTimelineDown( wxScrollEvent& event );
-    void OnTimelineUp( wxScrollEvent& event );
     void OnAll( wxCommandEvent& event );
-    void OnNow( wxCommandEvent& event );
     void OnUpdateDisplay( wxCommandEvent& event );
     void OnConfig( wxCommandEvent& event );
 
@@ -97,8 +91,6 @@ private:
     void OnCBAny( wxCommandEvent& event );
 
     void OnFitTimer( wxTimerEvent & ) { Fit(); }
-
-    void Now();
     
     wxWindow *pParent;
 

--- a/include/ClimatologyUI.h
+++ b/include/ClimatologyUI.h
@@ -48,8 +48,7 @@ class ClimatologyDialogBase : public wxDialog
 	private:
 
 	protected:
-		wxSpinCtrl* m_sDay;
-		wxBitmapButton* m_bpNow;
+
 		wxStaticText* m_stSpeed;
 		wxStaticText* m_stDirection;
 		wxTextCtrl* m_tWind;
@@ -64,21 +63,13 @@ class ClimatologyDialogBase : public wxDialog
 
 		// Virtual event handlers, override them in your derived class
 		virtual void OnClose( wxCloseEvent& event ) { event.Skip(); }
-		virtual void OnMonth( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnDay( wxSpinEvent& event ) { event.Skip(); }
 		virtual void OnAll( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnNow( wxCommandEvent& event ) { event.Skip(); }
-		virtual void OnTimeline( wxScrollEvent& event ) { event.Skip(); }
-		virtual void OnTimelineDown( wxScrollEvent& event ) { event.Skip(); }
-		virtual void OnTimelineUp( wxScrollEvent& event ) { event.Skip(); }
 		virtual void OnUpdateDisplay( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnConfig( wxCommandEvent& event ) { event.Skip(); }
 
 
 	public:
-		wxChoice* m_cMonth;
 		wxCheckBox* m_cbAll;
-		wxSlider* m_sTimeline;
 		wxCheckBox* m_cbWind;
 		wxCheckBox* m_cbCurrent;
 		wxCheckBox* m_cbPressure;

--- a/include/climatology_pi.h
+++ b/include/climatology_pi.h
@@ -60,7 +60,7 @@ extern QString qtStyleSheet;
 
 #define CLIMATOLOGY_TOOL_POSITION    -1          // Request default positioning of toolbar tool
 
-class climatology_pi : public opencpn_plugin_118
+class climatology_pi : public opencpn_plugin_121
 {
 public:
       climatology_pi(void *ppimgr);
@@ -108,6 +108,9 @@ public:
 
       void OnClimatologyDialogClose();
       void SendTimelineMessage(wxDateTime time);
+
+      /** Invoked by OpenCPN core when the selected time is updated in the timeline widget. */
+      virtual void OnTimelineSelectedTimeChanged(const wxDateTime &selectedTime);
 
 private:
       void FreeData();

--- a/src/ClimatologyUI.cpp
+++ b/src/ClimatologyUI.cpp
@@ -21,34 +21,10 @@ ClimatologyDialogBase::ClimatologyDialogBase( wxWindow* parent, wxWindowID id, c
 	fgSizer1->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_ALL );
 
 	wxStaticBoxSizer* sbSizer21;
-	sbSizer21 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Month") ), wxVERTICAL );
-
-	wxFlexGridSizer* fgSizer23;
-	fgSizer23 = new wxFlexGridSizer( 0, 0, 0, 0 );
-	fgSizer23->AddGrowableCol( 0 );
-	fgSizer23->SetFlexibleDirection( wxBOTH );
-	fgSizer23->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-
-	wxString m_cMonthChoices[] = { _("January"), _("Febuary"), _("March"), _("April"), _("May"), _("June"), _("July"), _("August"), _("September"), _("October"), _("November"), _("December") };
-	int m_cMonthNChoices = sizeof( m_cMonthChoices ) / sizeof( wxString );
-	m_cMonth = new wxChoice( sbSizer21->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxSize( 80,-1 ), m_cMonthNChoices, m_cMonthChoices, 0 );
-	m_cMonth->SetSelection( 0 );
-	fgSizer23->Add( m_cMonth, 0, wxALL|wxEXPAND, 5 );
-
-	m_sDay = new wxSpinCtrl( sbSizer21->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( -1,-1 ), wxSP_ARROW_KEYS, 1, 31, 1 );
-	fgSizer23->Add( m_sDay, 0, wxALL, 5 );
+	sbSizer21 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("Timeline Control") ), wxVERTICAL );
 
 	m_cbAll = new wxCheckBox( sbSizer21->GetStaticBox(), wxID_ANY, _("All"), wxDefaultPosition, wxDefaultSize, 0 );
-	fgSizer23->Add( m_cbAll, 0, wxALL, 0 );
-
-	m_bpNow = new wxBitmapButton( sbSizer21->GetStaticBox(), wxID_ANY, wxNullBitmap, wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW|0 );
-	fgSizer23->Add( m_bpNow, 0, wxALL, 0 );
-
-
-	sbSizer21->Add( fgSizer23, 1, wxEXPAND, 5 );
-
-	m_sTimeline = new wxSlider( sbSizer21->GetStaticBox(), wxID_ANY, 0, 1, 500, wxDefaultPosition, wxDefaultSize, wxSL_HORIZONTAL );
-	sbSizer21->Add( m_sTimeline, 0, wxEXPAND, 5 );
+	sbSizer21->Add( m_cbAll, 0, wxALL, 5 );
 
 
 	fgSizer1->Add( sbSizer21, 1, wxEXPAND, 5 );
@@ -193,25 +169,11 @@ ClimatologyDialogBase::ClimatologyDialogBase( wxWindow* parent, wxWindowID id, c
 	this->Layout();
 	fgSizer1->Fit( this );
 
-	this->Centre( wxBOTH );
+	// this->Centre( wxBOTH ); // Commented out to fix macOS centering crash
 
 	// Connect Events
 	this->Connect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( ClimatologyDialogBase::OnClose ) );
-	m_cMonth->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( ClimatologyDialogBase::OnMonth ), NULL, this );
-	m_sDay->Connect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ClimatologyDialogBase::OnDay ), NULL, this );
 	m_cbAll->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ClimatologyDialogBase::OnAll ), NULL, this );
-	m_bpNow->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ClimatologyDialogBase::OnNow ), NULL, this );
-	m_sTimeline->Connect( wxEVT_SCROLL_TOP, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Connect( wxEVT_SCROLL_BOTTOM, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Connect( wxEVT_SCROLL_LINEUP, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Connect( wxEVT_SCROLL_LINEDOWN, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Connect( wxEVT_SCROLL_PAGEUP, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Connect( wxEVT_SCROLL_PAGEDOWN, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Connect( wxEVT_SCROLL_THUMBTRACK, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Connect( wxEVT_SCROLL_THUMBRELEASE, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Connect( wxEVT_SCROLL_CHANGED, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Connect( wxEVT_SCROLL_LINEDOWN, wxScrollEventHandler( ClimatologyDialogBase::OnTimelineDown ), NULL, this );
-	m_sTimeline->Connect( wxEVT_SCROLL_LINEUP, wxScrollEventHandler( ClimatologyDialogBase::OnTimelineUp ), NULL, this );
 	m_cbWind->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ClimatologyDialogBase::OnUpdateDisplay ), NULL, this );
 	m_cbCurrent->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ClimatologyDialogBase::OnUpdateDisplay ), NULL, this );
 	m_cbPressure->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ClimatologyDialogBase::OnUpdateDisplay ), NULL, this );
@@ -230,21 +192,7 @@ ClimatologyDialogBase::~ClimatologyDialogBase()
 {
 	// Disconnect Events
 	this->Disconnect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( ClimatologyDialogBase::OnClose ) );
-	m_cMonth->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( ClimatologyDialogBase::OnMonth ), NULL, this );
-	m_sDay->Disconnect( wxEVT_COMMAND_SPINCTRL_UPDATED, wxSpinEventHandler( ClimatologyDialogBase::OnDay ), NULL, this );
 	m_cbAll->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ClimatologyDialogBase::OnAll ), NULL, this );
-	m_bpNow->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( ClimatologyDialogBase::OnNow ), NULL, this );
-	m_sTimeline->Disconnect( wxEVT_SCROLL_TOP, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Disconnect( wxEVT_SCROLL_BOTTOM, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Disconnect( wxEVT_SCROLL_LINEUP, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Disconnect( wxEVT_SCROLL_LINEDOWN, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Disconnect( wxEVT_SCROLL_PAGEUP, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Disconnect( wxEVT_SCROLL_PAGEDOWN, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Disconnect( wxEVT_SCROLL_THUMBTRACK, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Disconnect( wxEVT_SCROLL_THUMBRELEASE, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Disconnect( wxEVT_SCROLL_CHANGED, wxScrollEventHandler( ClimatologyDialogBase::OnTimeline ), NULL, this );
-	m_sTimeline->Disconnect( wxEVT_SCROLL_LINEDOWN, wxScrollEventHandler( ClimatologyDialogBase::OnTimelineDown ), NULL, this );
-	m_sTimeline->Disconnect( wxEVT_SCROLL_LINEUP, wxScrollEventHandler( ClimatologyDialogBase::OnTimelineUp ), NULL, this );
 	m_cbWind->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ClimatologyDialogBase::OnUpdateDisplay ), NULL, this );
 	m_cbCurrent->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ClimatologyDialogBase::OnUpdateDisplay ), NULL, this );
 	m_cbPressure->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( ClimatologyDialogBase::OnUpdateDisplay ), NULL, this );
@@ -819,7 +767,7 @@ ClimatologyConfigDialogBase::ClimatologyConfigDialogBase( wxWindow* parent, wxWi
 	this->Layout();
 	fgSizer3->Fit( this );
 
-	this->Centre( wxBOTH );
+	// this->Centre( wxBOTH ); // Commented out to fix macOS centering crash
 
 	// Connect Events
 	m_notebook1->Connect( wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED, wxNotebookEventHandler( ClimatologyConfigDialogBase::OnPageChanged ), NULL, this );

--- a/src/climatology_pi.cpp
+++ b/src/climatology_pi.cpp
@@ -74,7 +74,7 @@ wxString ClimatologyUserDataDirectory()
 }
 
 climatology_pi::climatology_pi(void *ppimgr)
-      :opencpn_plugin_118(ppimgr)
+      :opencpn_plugin_121(ppimgr)
 {
       m_pClimatologyDialog = nullptr;
       // Create the PlugIn icons
@@ -250,6 +250,12 @@ void climatology_pi::CreateOverlayFactory()
         m_pClimatologyDialog->FitLater(); // buggy wx
     }
     m_pClimatologyDialog->Hide();
+    
+    // Get the current timeline selection and apply it
+    wxDateTime timelineSelection = GetTimelineSelectedTime();
+    if(timelineSelection.IsValid()) {
+        OnTimelineSelectedTimeChanged(timelineSelection);
+    }
 }
 
 void climatology_pi::SetDefaults(void)
@@ -457,4 +463,11 @@ bool climatology_pi::SaveConfig(void)
 void climatology_pi::SetColorScheme(PI_ColorScheme cs)
 {
     DimeWindow(m_pClimatologyDialog);
+}
+
+void climatology_pi::OnTimelineSelectedTimeChanged(const wxDateTime &selectedTime)
+{
+    if(m_pClimatologyDialog) {
+        m_pClimatologyDialog->UpdateFromTimeline(selectedTime);
+    }
 }


### PR DESCRIPTION
Integrate the climatology plugin with OpenCPN's new timeline widget.

**Key Changes:**
- **Extend** plugin from `opencpn_plugin_121` to support timeline API
- **Implement** `OnTimelineSelectedTimeChanged()` to receive timeline updates
- **Add** startup sync with `GetTimelineSelectedTime()` to match current timeline state
- **Remove** all manual time controls: month/day pickers, timeline slider, and "Now" button
- **Simplify** UI to focus on climatology data display rather than time selection
- **Update** time handling logic to work entirely through timeline widget

**Result:** The plugin now provides a consistent temporal navigation experience across OpenCPN, automatically updating climatology data when users interact with the global timeline widget while maintaining all existing functionality for data visualization and configuration.

**⚠️ Dependencies:** This PR depends on upcoming OpenCPN core changes that are still in development:
1. New timeline API and widget implementation in OpenCPN core
2. Plugin API increment to version 1.21 
3. New OpenCPN release supporting plugin API 1.21
4. Updated `ocpn_plugin.h` published to opencpn-libs repository

In other words, it's not possible to merge this PR until OpenCPN core supports the timeline widget as a standard feature.

**🔬 Validation Purpose:** This PR serves as a validation test for the OpenCPN core timeline widget implementation.

<img width="628" alt="image" src="https://github.com/user-attachments/assets/4b2978ed-3b90-4c8f-a2fa-36d16541bb19" />

